### PR TITLE
Issue/12

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,32 @@
+# Troubleshooting / FAQ Guide
+
+As common issues or questions are encountered solutions will be added to this guide.
+
+## `NoProjectFound`
+
+portray raises this exception when it cant find a project in the current directory.
+This means that there is no `project.toml` or `setup.py` file in the directory you ran portray
+AND that you haven't specified modules to include on the command line.
+
+### Solution 1: Go to root of project
+If you do have a `pyproject.toml` or `setup.py` file in your project, chances are you simply accidentally ran
+portray from a different directory. Simply changing back to your projects root directory at the same level as
+these files should be enough to resolve your issue.
+
+### Solution 2: Create a pyproject.toml file
+You can create a simplified pyproject.toml file that explicitly specifies what modules are included in your project:
+
+```toml
+[tool.portray]
+modules = ["MY_MODULE"]
+```
+
+### Solution 3: Specify the modules manually from the command line
+Every CLI command supports explicitly setting one or more modules using `-m`:
+
+<script id="asciicast-264805" src="https://asciinema.org/a/264805.js" async></script>
+
+## Deploying to Netlify
+
+portray includes a built-in command to deploy to [Github Pages](https://pages.github.com/) but it's also compatible with every static website host, including the popular [Netflify](https://www.netlify.com).
+There's a great guide on how to set this up contributed by @sw-yx [here](https://scotch.io/@sw-yx/python-the-jamstack).

--- a/docs/quick_start/2.-cli.md
+++ b/docs/quick_start/2.-cli.md
@@ -26,6 +26,7 @@ Both commands take an optional `--port` and `--host` argument.
         [tool.portray]
         modules = ["portray"]
 
+    Or, if you want to avoid configuration files entirely, you can set modules explicitly on the command line using -m (Example: `portray server -m portray`.)
     Finally, portray pulls .md files from the root of your project and one dedicated documentation directory (defaulting to `docs`) by default.
     You can change the directory where docs are located by setting the `tool.portray.docs_dir` setting in `pyproject.toml`.
 

--- a/portray/exceptions.py
+++ b/portray/exceptions.py
@@ -12,7 +12,9 @@ class NoProjectFound(PortrayError):
 
     def __init__(self, directory: str):
         super().__init__(
-            self, "No Python project found in the given directory: '{}'".format(directory)
+            self,
+            "No Python project found in the given directory: '{}'".format(directory)
+            + " See: https://timothycrosley.github.io/portray/TROUBLESHOOTING/#noprojectfound",
         )
         self.directory = directory
 

--- a/portray/logo.py
+++ b/portray/logo.py
@@ -14,7 +14,6 @@ ascii_art = r"""
 
 Version: {}
 Copyright Timothy Edmund Crosley 2019 MIT License
-
 """.format(
     __version__
 )

--- a/portray/render.py
+++ b/portray/render.py
@@ -51,7 +51,7 @@ def pdoc3(config: dict) -> None:
     try:
         pdoc.cli.main(Namespace(**config))
     except TypeError as type_error:
-        if not "show_type_annotations=True" in config["config"]:
+        if "show_type_annotations=True" not in config["config"]:
             raise
 
         print(type_error)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.6"
 pdoc3 = "^0.6.3"
-hug = "^2.5"
+hug = "^2.6"
 mkdocs = "^1.0"
 toml = "^0.10.0"
 mkdocs-material = "^4.4"


### PR DESCRIPTION
Fixes issue #12 
- Adds the ability to specify modules from the command line
- Adds a troubleshooting guide for the `NoProjectFound` exception
- Links to the trouble shooting guide from the exception
- Adds smarts to attempt to pull modules out of simple setup.py files using ast
