### PR TITLE
update logging from CLI as_html for clarity

### DIFF
--- a/portray/api.py
+++ b/portray/api.py
@@ -38,7 +38,7 @@ def as_html(
         project_configuration(directory, config_file, modules), overwrite=overwrite
     )
     print(logo.ascii_art)
-    print("Documentation successfully generated into {}!".format(os.path.abspath(output_dir)))
+    print("Documentation successfully generated into `{}` !".format(os.path.abspath(output_dir)))
 
 
 def in_browser(


### PR DESCRIPTION
Purely cosmetic, just thought the current logging looked a little strange w/ the exclamation point, as if the file path was literally `path/to/dir!`.

before

![Screen Shot 2019-08-29 at 5 29 30 PM](https://user-images.githubusercontent.com/11388735/63977768-98d27780-ca82-11e9-8c1b-318f511a3dc2.png)

after

![Screen Shot 2019-08-29 at 5 29 23 PM](https://user-images.githubusercontent.com/11388735/63977777-9e2fc200-ca82-11e9-9501-d19b120a49d7.png)