### PR TITLE
Improves handling of Git remotes.

### DIFF
--- a/portray/config.py
+++ b/portray/config.py
@@ -1,6 +1,7 @@
 """Defines the configuration defaults and load functions used by `portray`"""
 import ast
 import os
+import re
 import warnings
 from typing import Any, Dict, List, Union, cast
 from urllib import parse
@@ -138,9 +139,9 @@ def repository(directory: str) -> dict:
     config = {}
     try:
         repo_url = Repo(directory).remotes.origin.url
-        if "http" in repo_url:
-            config["repo_url"] = repo_url
-            config["repo_name"] = parse.urlsplit(repo_url).path.rstrip(".git").lstrip("/")
+        _path = re.search("(:(//)?)([\w\.@\:/\-~]+)(\.git)?(/)?", repo_url).groups()[2]
+        config["repo_url"] = repo_url
+        config["repo_name"] = _path.split('/')[-1].rstrip('.git')
     except Exception:
         config = {}
 


### PR DESCRIPTION
PR solving #31.

Instead of assuming `http` url, use a regex to handle a wide variety of remotes (See https://www.debuggex.com/r/bqQVpMPy0AbsCsir).

It solves the `repo_name` issue, but a sideeffect is that the `repo_url` becomes a url from where the current user cloned the repo, not a general url for the repo in itself.  
