### PR TITLE
Fix getting real error messages from toml errors

### DIFF
--- a/portray/config.py
+++ b/portray/config.py
@@ -115,6 +115,12 @@ def toml(location: str) -> dict:
        Generally this is a `pyproject.toml` file at the root of the project
        with a `[tool.portray]` section defined.
     """
+    if not location or not os.path.exists(location):
+        # If location file does not exist
+
+        warnings.warn(f'\nNo config file found at location: "{location}"')
+        return {}
+
     try:
         toml_config = toml_load(location)
         tools = toml_config.get("tool", {})
@@ -133,8 +139,8 @@ def toml(location: str) -> dict:
                 config["modules"] = [tools["flit"]["metadata"]["module"]]
 
         return config
-    except Exception:
-        warnings.warn(f"No {location} config file found")
+    except Exception as loadConfigE:
+        warnings.warn(f'\nConfig file at "{location}" has errors: {loadConfigE}')
 
     return {}
 

--- a/portray/config.py
+++ b/portray/config.py
@@ -115,11 +115,16 @@ def toml(location: str) -> dict:
        Generally this is a `pyproject.toml` file at the root of the project
        with a `[tool.portray]` section defined.
     """
-    if not location or not os.path.exists(location):
-        # If location file does not exist
+    try:
+        location_exists = os.path.exists(location)
+        if not location_exists:
+            warnings.warn(f'\nNo config file found at location: "{location}"')
+            return {}
+    except Exception as detection_error:
+        warnings.warn(f'\nUnable to check config at "{location}" due to error: {detection_error}')
+        
 
-        warnings.warn(f'\nNo config file found at location: "{location}"')
-        return {}
+    
 
     try:
         toml_config = toml_load(location)

--- a/portray/config.py
+++ b/portray/config.py
@@ -139,8 +139,8 @@ def toml(location: str) -> dict:
                 config["modules"] = [tools["flit"]["metadata"]["module"]]
 
         return config
-    except Exception as loadConfigE:
-        warnings.warn(f'\nConfig file at "{location}" has errors: {loadConfigE}')
+    except Exception as load_config_error:
+        warnings.warn(f'\nConfig file at "{location}" has errors: {load_config_error}')
 
     return {}
 


### PR DESCRIPTION
This was hard coded to pretend every error is "file not found."

So change to explicitly checking if file exists for that message, otherwise log the exception message.

Before, with present pyproject.toml file, but lopsided quotes / missing a closing quote:

    /home/CENSORED/projects/AdvancedHTMLParser/myenv/lib/python3.6/site-packages/portray/config.py:137: UserWarning: No /home/CENSORED/projects/AdvancedHTMLParser/./pyproject.toml config file found
      warnings.warn(f"No {location} config file found")

After the change:

    /home/CENSORED/projects/AdvancedHTMLParser/myenv/lib/python3.6/site-packages/portray/config.py:143: UserWarning:
    Config file at "/home/CENSORED/projects/AdvancedHTMLParser/./pyproject.toml" has errors: Unbalanced quotes (line 2 column 118 char 132)
      warnings.warn(f'\nConfig file at "{location}" has errors: {loadConfigE}')

After the change, but with missing file:

    /home/CENSORED/projects/AdvancedHTMLParser/myenv/lib/python3.6/site-packages/portray/config.py:121: UserWarning:
    No config file found at location: "/home/CENSORED/projects/AdvancedHTMLParser/pyproject.toml"
      warnings.warn(f'\nNo config file found at location: "{location}"')

Not sure why you're using warnings... either get one super long line followed by a duplicate (but including source code!), or after my change get one less long line, one that contains the error message, and then source cod again.

I would use sys.stderr.write, myself, for just one line. Can make a decorator for "one time" error display, though I think this will always be once. Example here: https://github.com/kata198/indexedredis/blob/master/IndexedRedis/deprecated.py defines a decorator to print a message max once per run, can just call that directly if such is your intent.

I did not include such in this merge request, I kept with warnings.

Thanks!