### PR TITLE
Include markdown files only

### DIFF
--- a/portray/render.py
+++ b/portray/render.py
@@ -5,15 +5,14 @@ import os
 import shutil
 import sys
 import tempfile
-from argparse import Namespace
 from contextlib import contextmanager
 from glob import glob
 from typing import Dict
 
-import mako.exceptions
 import mkdocs.config as mkdocs_config
 import mkdocs.exceptions as _mkdocs_exceptions
 from mkdocs.commands.build import build as mkdocs_build
+from mkdocs.utils import is_markdown_file
 from pdocs import as_markdown as pdocs_as_markdown
 from yaspin import yaspin
 
@@ -87,7 +86,7 @@ def documentation_in_temp_folder(config: dict):
             ) as spinner:
                 for root_file in os.listdir(config["directory"]):
                     root_file_absolute = os.path.join(config["directory"], root_file)
-                    if os.path.isfile(root_file_absolute):
+                    if os.path.isfile(root_file_absolute) and is_markdown_file(root_file_absolute):
                         shutil.copyfile(root_file_absolute, os.path.join(input_dir, root_file))
 
                 for source_directory in [config["docs_dir"]] + config["extra_dirs"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ pep8-naming = "^0.8.2"
 hypothesis-auto = "^0.0.4"
 pprofile = "^2.0"
 
+[tool.black]
+line-length = 100
+
 [tool.poetry.scripts]
 portray = "portray.cli:__hug__.cli"
 


### PR DESCRIPTION
As I was writing in #55 this is my suggestion about how to avoid including any file laying around in the repo root dir when creating the `site` output directory.

While I was working on it, I've discovered that MkDocs already has an utility function which defines what a markdown file is. So I've decided to retain that definition and select the files in the root dir based on what MkDocs does.

While doing that I've also removed some unused import statements. Moreover I've also added an explicit max line length for black in the `pyproject.toml`.

Any feedback or concern are more than welcome.