### PR TITLE
Fix `api.project_configuration` overriding `output_dir`

### DIFF
--- a/portray/api.py
+++ b/portray/api.py
@@ -143,7 +143,7 @@ def project_configuration(
     directory: str = "",
     config_file: str = "pyproject.toml",
     modules: list = None,
-    output_dir: str = "site",
+    output_dir: str = None,
 ) -> dict:
     """Returns the configuration associated with a project.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -42,6 +42,12 @@ Troubleshooting = "TROUBLESHOOTING.md"
     "4. Configuration" = "docs/quick_start/4.-configuration.md"
 """
 
+FAKE_PYPROJECT_TOML_BASIC = """
+[tool.portray]
+modules = ["my_module"]
+output_dir = "docs_output"
+"""
+
 
 def test_as_html(temporary_dir, project_dir, chdir):
     with chdir(temporary_dir):
@@ -155,3 +161,11 @@ def test_module_no_path(temporary_dir, chdir):
             pyproject.write("[tool.portray]\nappend_directory_to_python_path = false")
         with pytest.raises(Exception):
             api.as_html()
+
+
+def test_setting_output_dir_in_pyproject_overwrites_default(temporary_dir):
+    config_file = os.path.join(temporary_dir, "pyproject.toml")
+    with open(config_file, "w") as pyproject:
+        pyproject.write(FAKE_PYPROJECT_TOML_BASIC)
+    config = api.project_configuration(directory=temporary_dir, config_file=config_file)
+    assert config["output_dir"] == "docs_output"


### PR DESCRIPTION
This function in the api module was unwittingly overwriting `output_dir` args passed along from `pyproject.toml`.

Added a regression test.

Fixes #63