### PR TITLE
FIx issue 83

### DIFF
--- a/portray/render.py
+++ b/portray/render.py
@@ -12,6 +12,7 @@ from typing import Dict, Iterator, Tuple
 import mkdocs.config as mkdocs_config
 import mkdocs.exceptions as _mkdocs_exceptions
 from mkdocs.commands.build import build as mkdocs_build
+from mkdocs.config.defaults import get_schema as mkdocs_schema
 from mkdocs.utils import is_markdown_file
 from pdocs import as_markdown as pdocs_as_markdown
 from yaspin import yaspin
@@ -169,7 +170,7 @@ def documentation_in_temp_folder(config: dict) -> Iterator[Tuple[str, str]]:
 
 
 def _mkdocs_config(config: dict) -> mkdocs_config.Config:
-    config_instance = mkdocs_config.Config(schema=mkdocs_config.DEFAULT_SCHEMA)
+    config_instance = mkdocs_config.Config(schema=mkdocs_schema())
     config_instance.load_dict(config)
 
     errors, warnings = config_instance.validate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.6"
 hug = "^2.6"
-mkdocs = "^1.0"
+mkdocs = "~1.2"
 pdocs = "^1.1.1"
 toml = "^0.10.0"
 mkdocs-material = "^7.0"


### PR DESCRIPTION
This is a `mkdocs` compatibility fix pointed out by @Peter200lx .  

To help avoid surprises like this, I was wondering if it would make sense to pin an exact version of `mkdocs` (and others).  Currently, only a major version is specified:

https://github.com/timothycrosley/portray/blob/371ab8bce9ebd0ba6b77bc5e8c1d318a0e3aa428/pyproject.toml#L12

