### PR TITLE
Ensure '', false, and False are accepted for include_reference_documentation

### DIFF
--- a/portray/render.py
+++ b/portray/render.py
@@ -142,9 +142,10 @@ def documentation_in_temp_folder(config: dict) -> Iterator[Tuple[str, str]]:
                                 os.path.join(input_dir, index_page), destination_index_page
                             )
 
-            if config["include_reference_documentation"] and config[
-                "include_reference_documentation"
-            ] not in ("false", "False"):
+            if config["include_reference_documentation"] and (
+                config["include_reference_documentation"] not in ("false", "False")
+                or config["include_reference_documentation"]
+            ):
                 with yaspin(text="Auto generating reference documentation using pdocs") as spinner:
                     if "output_dir" not in config["pdocs"]:
                         config["pdocs"]["output_dir"] = os.path.join(input_dir, "reference")

--- a/portray/render.py
+++ b/portray/render.py
@@ -142,7 +142,9 @@ def documentation_in_temp_folder(config: dict) -> Iterator[Tuple[str, str]]:
                                 os.path.join(input_dir, index_page), destination_index_page
                             )
 
-            if config["include_reference_documentation"]:
+            if config["include_reference_documentation"] and config[
+                "include_reference_documentation"
+            ] not in ("false", "False"):
                 with yaspin(text="Auto generating reference documentation using pdocs") as spinner:
                     if "output_dir" not in config["pdocs"]:
                         config["pdocs"]["output_dir"] = os.path.join(input_dir, "reference")
@@ -160,7 +162,9 @@ def documentation_in_temp_folder(config: dict) -> Iterator[Tuple[str, str]]:
                 del config["mkdocs"]["docs_dir"]
             if config["mkdocs"]["site_dir"].startswith(temp_output_dir):
                 del config["mkdocs"]["site_dir"]
-            if config["pdocs"]["output_dir"].startswith(input_dir):
+            if config["pdocs"].get("output_dir") and config["pdocs"]["output_dir"].startswith(
+                input_dir
+            ):
                 del config["pdocs"]["output_dir"]
             if config["include_reference_documentation"]:
                 nav.pop()


### PR DESCRIPTION
The config parameter `include_reference_documentation` is somehow rendered to a string when set in PyProject.toml, and the falsey check doesn't work.  This change checks the string values "", "false", and "False" to correctly enable this feature.

The second change ensures that in the case of empty string, `include_reference_documentation=""`, there is no KeyError during cleanup.

I've retained the original truthy evaluation in case there is some code path that uses it, for example, if it gets it directly from the default config Python file.