### PR TITLE
Add an example of mkdocs general settings that has come up before

### DIFF
--- a/docs/quick_start/4.-configuration.md
+++ b/docs/quick_start/4.-configuration.md
@@ -36,6 +36,13 @@ name = "material"
 palette = {primary = "blue grey", accent = "pink"}
 ```
 
+Another example, if you are stuck on a legacy `master` branch, set the following in `pyproject.toml`:
+
+```toml
+[tool.portray.mkdocs]
+edit_uri = "edit/master"
+```
+
 TOML doesn't behave 1:1 with YAML, and as a result, in some cases portray forces a stricter form of configuration options.
 For instance, to set up a custom navigation structure with portray, you can either specify just a flat list of file names, or a list of mappings of `{LABEL: FILENAME or LIST_OF_MAPPING}` but not a mix of both.
 This still allows as much customization as is permitted by mkdocs just with more consistency enforced. The recommended form is always to use lists of mappings.


### PR DESCRIPTION
This issue has come up before and is expected to be common. By explicitly showing in the config, users can understand how to set general mkdocs settings and quickly solve a problem.